### PR TITLE
Bot half rewrite to work with nicknames

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ If you want to use this bot on your server you will need to edit:
 
 `bot.py` - edit roles and channels
 
-`settings.json` - you only need to insert your bot token and Hypixel api key (you need to run the bot once to generate `settings.json` file)
+`settings.json` - you only need to insert your bot token and Hypixel api key (you need to run the bot once to generate`settings.json` file)
 
 To start the bot you will need Python 3 and run `python3 entry.py`

--- a/bot.py
+++ b/bot.py
@@ -1,6 +1,8 @@
 import discord
 import asyncio
-from discord.ext import commands
+from discord.ext import commands, tasks
+from datetime import datetime
+import simplejson.errors
 
 from settings import *
 from hypixel_api import *
@@ -13,8 +15,23 @@ class StopAction(Enum):
     UPDATE = auto()
 
 
-def channelSuitableForCommands(channel):
-    return "bot" in channel.name
+logging_channel = 874233307548753934  # int
+bot_channels = [874233307238367299, 874233306672156701, 874233306424684594]  # list
+officer_role = 874233306424684590  # int
+hypixel_guild_id = "5ff980828ea8c9e004b008e2"  # str
+
+
+def name_to_uuid(name):
+    url = f"https://api.mojang.com/users/profiles/minecraft/{name}"
+    try:
+        return requests.get(url).json()["id"]
+    except simplejson.errors.JSONDecodeError:
+        return "Error"
+
+
+def channelSuitableForCommands(channel_id):
+    if channel_id in bot_channels:
+        return True
 
 
 async def getRoleByName(guild: discord.Guild, role_name):
@@ -25,7 +42,7 @@ async def getRoleByName(guild: discord.Guild, role_name):
 
 async def isOfficer(user):
     for role in user.roles:
-        if role.name == "Officer":
+        if role.id == officer_role:
             return True
     return False
 
@@ -37,17 +54,37 @@ async def memberHasRole(member, role_name):
     return False
 
 
+class MyHelp(commands.HelpCommand):
+    def get_command_signature(self, command):
+        return '%s%s %s' % (self.clean_prefix, command.qualified_name, command.signature)
+
+    async def send_bot_help(self, mapping):
+        embed = discord.Embed(title="Help", color=0xdcb824)
+        for cog, commands in mapping.items():
+            filtered = await self.filter_commands(commands, sort=True)
+            command_signatures = [self.get_command_signature(c) for c in filtered]
+            if command_signatures:
+                cog_name = getattr(cog, "qualified_name", "No Category")
+                embed.add_field(name=cog_name, value="\n".join(command_signatures), inline=False)
+
+        channel = self.get_destination()
+        await channel.send(embed=embed)
+
+
 class HypixelSloveniaDiscordBot(commands.Bot):
     def __init__(self, channel_shutdown_id):
         intents = discord.Intents.default()
         intents.members = True
-        super().__init__(command_prefix=".", intents=intents)
+        super().__init__(command_prefix=".", intents=intents,
+                         activity=discord.Activity(type=discord.ActivityType.listening, name=".help"),
+                         status=discord.Status.online)
         self.settings = Settings()
         self.hypixel_api = HypixelApi()
         self.addCommands()
         self.stop_action = StopAction.NONE
         self.channel_shutdown_id = channel_shutdown_id
         asyncio.set_event_loop(asyncio.new_event_loop())
+        self.help_command = MyHelp()
 
     async def on_ready(self):
         print("Bot has started")
@@ -68,60 +105,101 @@ class HypixelSloveniaDiscordBot(commands.Bot):
             self.stop_action = StopAction.SHUTDOWN
 
     def addCommands(self):
-        @self.command(pass_context=True, aliases=["u"])
+        # update self or @user  Won't work if user doesn't have "Member" role
+        @self.command(help="Posodobi rank in level.", pass_context=True, aliases=["u"])
         async def update(ctx: discord.ext.commands.context.Context, member: discord.Member = None):
-            if not channelSuitableForCommands(ctx.channel):
+            if not channelSuitableForCommands(ctx.channel.id):
                 return
 
             if member is None:
                 member = ctx.author
 
             if member.id != ctx.author.id and not await isOfficer(ctx.author):
-                await ctx.send(f"Nimas dovoljenja da updatas druge uporabnike")
+                await ctx.send(f"Nimaš dovoljenja da posodabljaš druge uporabnike.")
                 return
 
-            await self.updateMember(ctx, member)
+            display_name = member.display_name
 
-        @self.command(pass_context=True, aliases=["ua"])
+            await self.updateMember(ctx, display_name, member)
+
+        # updates all users with "Member" role
+        @self.command(pass_context=True)
         @commands.has_permissions(administrator=True)
         async def updateall(ctx: discord.ext.commands.context.Context):
-            if not channelSuitableForCommands(ctx.channel):
+            log_channel = self.get_channel(logging_channel)
+            await log_channel.send("**Updateall started**")
+            if not channelSuitableForCommands(ctx.channel.id):
                 return
-
             for member in ctx.guild.members:
-                if memberHasRole(member, "Linked"):
-                    try:
-                        await self.updateMember(ctx, member)
-                    except Exception as exception:
-                        await ctx.send(f"Python exception occurred for user {member.display_name}")
-                        print(exception)
+                try:
+                    await self.updateMember(ctx, member.display_name, member)
+                except Exception as exception:
+                    await ctx.send(f"Python exception occurred for user {member.display_name}")
+                    print(exception)
             await ctx.send(f"Updated all linked players!")
+            await log_channel.send("**Updateall ended**")
 
-        @self.command(pass_context=True)
-        async def p(ctx: discord.ext.commands.context.Context, minecraft_name, member: discord.Member = None):
-            if not channelSuitableForCommands(ctx.channel):
+        # verify
+        @self.command(help="Preveri se", pass_context=True, aliases=["p"])
+        @commands.has_any_role(officer_role, "Nepreverjeni")
+        async def preveri(ctx: discord.ext.commands.context.Context, minecraft_name, member: discord.Member = None):
+            log_channel = self.get_channel(logging_channel)
+            member_role = await getRoleByName(ctx.guild, "Member")
+            nepreverjeni_role = await getRoleByName(ctx.guild, "Nepreverjeni")
+
+            if not channelSuitableForCommands(ctx.channel.id):
+                return
+            if member is None:
+                member = ctx.author
+            if nepreverjeni_role not in member.roles:
+                await ctx.send("Preveriš lahko samo uporabnike, ki niso preverjeni.")
                 return
 
             try:
-                if member is None:
-                    member = ctx.author
+                uuid = name_to_uuid(minecraft_name)
+                # if player doesn't exist
+                if uuid == "Error":
+                    await ctx.send(f"`{minecraft_name}` ne obstaja.")
+                    return
+                update_name = f"{minecraft_name} [0]"
 
-                player = await self.hypixel_api.getPlayerByName(minecraft_name)
+                player = await self.hypixel_api.getPlayerByUUID(uuid)
 
                 if player.discord is None:
+                    # if player discord doesn't exist
                     if await isOfficer(ctx.author):
-                        await ctx.send(f"{minecraft_name} "
-                                       f"nima registriranega discorda na hypixlu vendar se bo se vseeno povezal")
-                    else:
-                        await ctx.send(f"{minecraft_name} nima registriranega discorda na hypixlu!")
+                        await ctx.send(f"Preveril `{member}` kot `{minecraft_name}`!")
+                        await member.add_roles(member_role)
+                        await member.remove_roles(nepreverjeni_role)
+                        await log_channel.send(f"**Preveril** `{member}` kot `{minecraft_name}`!")
+                        await member.edit(nick=f"{minecraft_name} [0]")
+                        await self.updateMember(ctx, update_name, member)
                         return
+                    else:
+                        await ctx.send(f"`{minecraft_name}` nima registriranega discorda na Hypixlu. Počakaj na "
+                                       f"<@&{officer_role}> da te preveri!")
+                        return
+                    # if player discord doesn't match
                 elif player.discord != f"{member.name}#{member.discriminator}":
-                    await ctx.send("Discorda se na ujemata!")
-                    return
-
-                asyncio.ensure_future(self.settings.linkUser(member.id, player.uuid))
-                await member.add_roles(await getRoleByName(ctx.guild, "Povezan"))
-                await ctx.send("Povezava uspesna!")
+                    if await isOfficer(ctx.author):
+                        await ctx.send(f"Preveril `{member}` kot `{minecraft_name}`!")
+                        await log_channel.send(f"**Preveril** `{member}` kot `{minecraft_name}`!")
+                        await member.add_roles(member_role)
+                        await member.remove_roles(nepreverjeni_role)
+                        await member.edit(nick=f"{minecraft_name} [0]")
+                        await self.updateMember(ctx, update_name, member)
+                        return
+                    else:
+                        await ctx.send(f"Tvoj discord se ne ujema počakaj na <@&{officer_role}>")
+                        return
+                    # if player discord matches
+                elif player.discord == f"{member.name}#{member.discriminator}":
+                    await ctx.send(f"Preveril `{member}` kot `{minecraft_name}`!")
+                    await log_channel.send(f"**Preveril** `{member}` kot `{minecraft_name}`!")
+                    await member.add_roles(member_role)
+                    await member.remove_roles(nepreverjeni_role)
+                    await member.edit(nick=f"{minecraft_name} [0]")
+                    await self.updateMember(ctx, update_name, member)
 
             except HypixelApiError as error:
                 await ctx.send(f"Napaka: {error}")
@@ -129,52 +207,77 @@ class HypixelSloveniaDiscordBot(commands.Bot):
         @self.command(pass_context=True)
         @commands.has_permissions(administrator=True)
         async def shutdown(ctx: discord.ext.commands.context.Context):
-            if not channelSuitableForCommands(ctx.channel):
+            if not channelSuitableForCommands(ctx.channel.id):
                 return
+            log_channel = self.get_channel(logging_channel)
             self.stop_action = StopAction.SHUTDOWN
             self.channel_shutdown_id = ctx.channel.id
             await ctx.send("Shutting down")
+            await log_channel.send("Shutting down!")
             await ctx.bot.close()
 
         @self.command(pass_context=True)
         @commands.has_permissions(administrator=True)
         async def restart(ctx: discord.ext.commands.context.Context):
-            if not channelSuitableForCommands(ctx.channel):
+            log_channel = self.get_channel(logging_channel)
+            if not channelSuitableForCommands(ctx.channel.id):
                 return
             self.stop_action = StopAction.RESTART
             self.channel_shutdown_id = ctx.channel.id
             await ctx.send("Restarting")
+            await log_channel.send("Restarting")
             await ctx.bot.close()
 
-        # Displays linked users inside settings.json with uuid and discordID's
-        @self.command(pass_context=True)
-        @commands.has_permissions(administrator=True)
-        async def linkdata(ctx: discord.ext.commands.context.Context):
-            if not channelSuitableForCommands(ctx.channel):
-                return
-            with open("settings.json") as f:
-                json_data = json.load(f)
-            await ctx.send(json_data["linked"])
+        #
+        # @self.command(pass_context=True)
+        # @commands.has_permissions(administrator=True)
+        # async def ping(ctx: discord.ext.commands.context.Context):
+        #    if not channelSuitableForCommands(ctx.channel.id):
+        #        return
+        #    await ctx.send("Pong")
 
-        # Displays what Minecraft UUID is linked to inputted Discord ID in setting.json
-        @self.command(pass_context=True)
-        @commands.has_permissions(administrator=True)
-        async def linkdatauuid(ctx: discord.ext.commands.context.Context, get_uuid_data):
-            if not channelSuitableForCommands(ctx.channel):
-                return
-            with open("settings.json") as f:
-                json_data = json.load(f)
-            await ctx.send("`Minecraft UUID linked to used Discord ID is:` "+str(json_data["linked"][get_uuid_data]))
+        # checkes every 1h if it's between 3-4am and if it is then updates all users
+        @tasks.loop(minutes=60.0)
+        async def task(ctx: discord.ext.commands.context.Context):
+            log_channel = self.get_channel(logging_channel)
+            # sam da vidm če ta srane dela dej stran če js nism
+            print(f"Check time: {datetime.now().hour}")
+            if datetime.now().hour == 3:
+                await log_channel.send("**Updateall started** *autoupdate*")
+                if not channelSuitableForCommands(ctx.channel.id):
+                    return
+                for member in ctx.guild.members:
+                    try:
+                        await self.updateMember(ctx, member.display_name, member)
+                    except Exception as exception:
+                        await log_channel.send(f"Python exception occurred for user {member.display_name}")
+                        print(exception)
+                await log_channel.send("**Updateall ended** *autoupdate*")
 
-    async def updateMember(self, ctx, member):
+    # function to update members   Won't work if user doesn't have "Member" role
+    async def updateMember(self, ctx, display_name, member):
+        member_role = discord.utils.find(lambda r: r.name == 'Member', ctx.message.guild.roles)
+        guild_role = discord.utils.find(lambda r: r.name == 'Guild Member', ctx.message.guild.roles)
+        log_channel = self.get_channel(logging_channel)
         try:
-            if not await self.settings.isUserLinked(member.id):
-                await ctx.send("Ta uporabnik ni povezan z minecraft racunom")
+            # check if user has member role
+            if member_role not in member.roles:
                 return
-            uuid = await self.settings.getLinkedUser(member.id)
+            name = str(display_name)
+            name_split = name.split()
+            uuid = name_to_uuid(name_split[0])
+            # if name doesn't exist unverifyes user
+            if uuid == "Error":
+                await log_channel.send(f"`{name_split[0]}` ne obstaja. Od-preveril `{member}`")
+                for role_name in ["VIP", "VIP+", "MVP", "MVP+", "MVP++", "Member", "Guild Member"]:
+                    await member.remove_roles(await getRoleByName(ctx.guild, role_name))
+                await member.add_roles(await getRoleByName(ctx.guild, "Nepreverjeni"))
+                await member.edit(nick="")
+                return
+            # check & edit rank roles, nick and guild member role
             player = await self.hypixel_api.getPlayerByUUID(uuid)
+            guild = await self.hypixel_api.getGuildByUUID(uuid)
             rank_name = "NON"
-
             if player.rank == HypixelRank.VIP:
                 rank_name = "VIP"
             elif player.rank == HypixelRank.VIP_PLUS:
@@ -192,11 +295,25 @@ class HypixelSloveniaDiscordBot(commands.Bot):
 
             if player.rank == HypixelRank.MVP_PLUS_PLUS:
                 await member.add_roles(await getRoleByName(ctx.guild, "MVP++"))
+            # check if member is in guild (check users without "Guild Member" role)
+            if guild_role not in member.roles:
+                if guild.guild_id == hypixel_guild_id:
+                    await member.add_roles(await getRoleByName(ctx.guild, "Guild Member"))
+                    await log_channel.send(f"Dodal `Guild Member` `{player.username}`.")
+            # check if someone with guild member role isn't in guild then remove all non moderator guild roles
+            if guild_role in member.roles:
+                if guild.guild_id != hypixel_guild_id:
+                    await member.remove_roles(await getRoleByName(ctx.guild, "Guild Member"), await getRoleByName(ctx.guild, "Veteran"), await getRoleByName(ctx.guild, "Professional"))
+                    await log_channel.send(f"Odstranil use Guild role od `{player.username}`.")
 
             await member.edit(nick=f"{player.username} [{player.network_level}]")
 
             await ctx.send(f"Posodobil {player.username} level na {player.network_level} in rank {rank_name}"
                            f"{' in MVP++' if player.rank == HypixelRank.MVP_PLUS_PLUS else ''}")
+
+            await log_channel.send(f"Posodobil `{player.username}` level na `{player.network_level}` in rank"
+                                   f" `{rank_name}`"
+                                   f"{' in `MVP++`' if player.rank == HypixelRank.MVP_PLUS_PLUS else ''}")
 
         except HypixelApiError as error:
             await ctx.send(f"Napaka: {error}")

--- a/bot.py
+++ b/bot.py
@@ -15,9 +15,9 @@ class StopAction(Enum):
     UPDATE = auto()
 
 
-logging_channel = 874233307548753934  # int
-bot_channels = [874233307238367299, 874233306672156701, 874233306424684594]  # list
-officer_role = 874233306424684590  # int
+logging_channel = 886285830950383687  # int
+bot_channels = [886285672208539698, 886285672208539698, 886285672208539698, 886285672208539698]  # list
+officer_role = 798483000404869121  # int
 hypixel_guild_id = "5ff980828ea8c9e004b008e2"  # str
 
 
@@ -64,7 +64,7 @@ class MyHelp(commands.HelpCommand):
             filtered = await self.filter_commands(commands, sort=True)
             command_signatures = [self.get_command_signature(c) for c in filtered]
             if command_signatures:
-                cog_name = getattr(cog, "qualified_name", "No Category")
+                cog_name = getattr(cog, "qualified_name", "Commands")
                 embed.add_field(name=cog_name, value="\n".join(command_signatures), inline=False)
 
         channel = self.get_destination()

--- a/hypixel_api.py
+++ b/hypixel_api.py
@@ -28,7 +28,6 @@ class HypixelApiError(Exception):
 class HypixelPlayer:
     def __init__(self, data: dict):
         self.username = data["player"]["displayname"]
-
         network_experience = data["player"]["networkExp"]
         network_level = (math.sqrt((2 * network_experience) + 30625) / 50) - 2.5
         self.network_level = math.floor(network_level)
@@ -40,7 +39,7 @@ class HypixelPlayer:
                 self.rank = rank_names[data["player"]["monthlyPackageRank"]]
         except KeyError or ValueError:
             pass
-            
+
         self.discord = None
         try:
             self.discord = data["player"]["socialMedia"]["links"]["DISCORD"]
@@ -50,10 +49,16 @@ class HypixelPlayer:
         self.uuid = data["player"]["uuid"]
 
 
+class Guild:
+    def __init__(self, data: dict):
+        self.guild_id = data["guild"]["_id"]
+
+
 class HypixelApi:
     def __init__(self):
         self.__key = ""
         self.__saved_players = {}
+        self.__saved_guilds = {}
 
     async def setKey(self, key: str):
         self.__key = key
@@ -66,6 +71,10 @@ class HypixelApi:
         url = f"https://api.hypixel.net/player?key={self.__key}&name={name}"
         return requests.get(url).json()
 
+    async def __fetchGuildFromUUID(self, uuid):
+        url = f"https://api.hypixel.net/guild?key={self.__key}&player={uuid}"
+        return requests.get(url).json()
+
     async def __savePlayerData(self, data, uuid):
         if data["success"]:
             if data["player"] is None:
@@ -75,6 +84,22 @@ class HypixelApi:
             cause = data["cause"]
             if cause == "You have already looked up this name recently":
                 if uuid not in self.__saved_players.keys():
+                    raise HypixelApiError("Cannot access player data and there is no fallback data")
+                else:
+                    return
+            else:
+                raise HypixelApiError(cause)
+
+    async def __saveGuildData(self, data, uuid):
+        if data["success"]:
+            if data["guild"] is None:
+                raise HypixelApiError("This player does not exist")
+            self.__saved_guilds[data["guild"]["_id"]] = Guild(data)
+        else:
+            cause = data["cause"]
+            if cause == "You have already looked up this name recently":
+                if uuid not in self.__saved_guilds.keys():
+                    print("__saveGuildData 5")
                     raise HypixelApiError("Cannot access player data and there is no fallback data")
                 else:
                     return
@@ -94,3 +119,9 @@ class HypixelApi:
         await self.__savePlayerData(data, uuid)
 
         return self.__saved_players[uuid]
+
+    async def getGuildByUUID(self, uuid) -> Guild:
+        data = await self.__fetchGuildFromUUID(uuid)
+
+        await self.__saveGuildData(data, uuid)
+        return self.__saved_guilds[data["guild"]["_id"]]

--- a/settings.py
+++ b/settings.py
@@ -6,9 +6,8 @@ class Settings:
     def __init__(self):
         self.__filename = None
         self.__settings = {
-            "linked": {},
             "discord_key": "insert your discord bot key here",
-            "hypixel_key": "insert your hypixel api key here",
+            "hypixel_key": "insert your hypixel api key here"
         }
 
     async def save(self):
@@ -39,13 +38,3 @@ class Settings:
 
     async def getHypixelKey(self):
         return self.__settings["hypixel_key"]
-
-    async def getLinkedUser(self, user_id):
-        return self.__settings["linked"][str(user_id)]
-
-    async def isUserLinked(self, user_id):
-        return str(user_id) in self.__settings["linked"]
-
-    async def linkUser(self, user_id, uuid):
-        self.__settings["linked"][str(user_id)] = uuid
-        await self.save()


### PR DESCRIPTION
1. Removed all linking stuff and made bot work with user nicknames *didn't we have this before? nah man you crazy*
2. New verifying system
3. Made updating work with new system + now updates "Guild Member" role
4. New help command 
5. Logging channel
6. You can now define bot channels in bot.py 
7. Bot now as a status `Listening to .help`